### PR TITLE
Remove duplicate ModelResponse export

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -189,7 +189,6 @@ __all__ = [
     "ToolCallItem",
     "ToolCallOutputItem",
     "ReasoningItem",
-    "ModelResponse",
     "ItemHelpers",
     "RunHooks",
     "AgentHooks",


### PR DESCRIPTION
## Summary
- avoid exporting `ModelResponse` twice from `src/agents/__init__.py`

## Testing
- `ruff format --check`
- `ruff check`
- `mypy .` *(fails: Cannot find implementation or library stub for many modules)*
- `python -m pytest -q` *(fails: No module named pytest)*