### PR TITLE
Add Next.js UI skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 .aider*
+
+# Node
+ui/node_modules/

--- a/README.md
+++ b/README.md
@@ -176,3 +176,15 @@ We'd like to acknowledge the excellent work of the open-source community, especi
 -   [uv](https://github.com/astral-sh/uv) and [ruff](https://github.com/astral-sh/ruff)
 
 We're committed to continuing to build the Agents SDK as an open source framework so others in the community can expand on our approach.
+
+## UI Development
+
+The optional UI is built with Next.js 15.3, React 19.1, Tailwind CSS 4.1.3 and shadcn/ui 2.5.0. To set it up:
+
+```bash
+cd ui
+npm install
+npm run dev
+```
+
+This starts the development server on <http://localhost:3000>.

--- a/setup.sh
+++ b/setup.sh
@@ -56,6 +56,13 @@ source "$NVM_DIR/nvm.sh"
 nvm install "$NODE_VERSION" || nvm install node --reinstall-packages-from=node
 nvm use "$NODE_VERSION" || nvm use node
 
+if [ -d "ui" ]; then
+  echo "➤ Installing UI dependencies"
+  pushd ui >/dev/null
+  npm install
+  popd >/dev/null
+fi
+
 echo "➤ pre-commit"
 pre-commit install
 

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -1,0 +1,10 @@
+import './globals.css';
+import type { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">OpenAI Agents UI</h1>
+      <p className="mt-4">Welcome to the Next.js interface.</p>
+    </div>
+  );
+}

--- a/ui/next-env.d.ts
+++ b/ui/next-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/messages/typescript-error-requiring-typescript
+
+interface ImportMetaEnv {
+  readonly NEXT_RUNTIME?: 'edge' | 'nodejs';
+}

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: { appDir: true }
+};
+
+module.exports = nextConfig;

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "agents-ui",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "15.3.0",
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
+    "tailwindcss": "4.1.3",
+    "shadcn-ui": "2.5.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/ui/postcss.config.js
+++ b/ui/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/ui/tailwind.config.ts
+++ b/ui/tailwind.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from 'tailwindcss';
+
+export default {
+  content: ['./app/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [require('shadcn-ui')],
+} satisfies Config;

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add `ui` folder with Next.js 15 skeleton using Tailwind and shadcn/ui
- ignore Node modules
- document UI setup instructions in README
- install UI packages from `setup.sh`

## Testing
- `make verify` *(fails: No route to host)*